### PR TITLE
0.3 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,20 @@ jobs:
         with:
           command: clippy
           args: --workspace
+
+  docs:
+    name: Deluxe Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rust-docs
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deluxe"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Procedural macro attribute parser"
 license = "MIT"
@@ -19,8 +19,8 @@ proc-macro = ["syn/proc-macro"]
 once_cell = "1.13.0"
 proc-macro2 = "1.0.38"
 syn = { version = "1.0.96", features = ["full", "parsing"], default-features = false }
-deluxe-core = { path = "./core", version = "0.2.0" }
-deluxe-macros = { path = "./macros", version = "0.2.0" }
+deluxe-core = { path = "./core", version = "0.3.0" }
+deluxe-macros = { path = "./macros", version = "0.3.0" }
 
 [dev-dependencies]
 quote = "1.0.18"

--- a/README.md
+++ b/README.md
@@ -287,15 +287,15 @@ pub fn derive_my_description(item: TokenStream) -> TokenStream {
 
     let ident = &input.ident;
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
-    let errors = errors.into_compile_error();
 
+    // Make sure to include the errors in the output
     let tokens = quote::quote! {
+        #errors
         impl #impl_generics #ident #type_generics #where_clause {
             fn my_desc() -> &'static str {
                 concat!("Name: ", #name, ", Version: ", #version #(, ", Author: ", #authors)*)
             }
         }
-        #errors
     };
     tokens.into()
 }
@@ -332,7 +332,7 @@ pub fn my_desc_mod(
         }
     });
 
-    let errors = errors.into_compile_error();
+    // Make sure to include the errors in the output
     let tokens = quote::quote! { #module #errors };
     tokens.into()
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deluxe-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Core traits and helpers for Deluxe procedural macro attribute parser"
 license = "MIT"

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -13,6 +13,7 @@
 //! of how Deluxe works.
 
 #![deny(missing_docs)]
+#![deny(unsafe_code)]
 
 mod parse_attributes;
 pub mod parse_helpers;

--- a/core/parse_helpers.rs
+++ b/core/parse_helpers.rs
@@ -141,7 +141,7 @@ impl<T> FieldStatus<T> {
                 if self.is_none() {
                     *self = FieldStatus::ParseError;
                 }
-                skip_named_meta_item(input);
+                skip_meta_item(input);
             }
         }
     }
@@ -163,7 +163,7 @@ impl<T> FieldStatus<T> {
             Some(v) => *self = FieldStatus::Some(v),
             None => {
                 *self = FieldStatus::ParseError;
-                skip_named_meta_item(input);
+                skip_meta_item(input);
             }
         }
     }
@@ -511,7 +511,7 @@ where
 /// Callers will typically check the field name for a match, and then call
 /// [`parse_named_meta_item`] or [`parse_named_meta_item_with`](fn@parse_named_meta_item_with).
 ///
-/// Callers will usually want to use [`check_unknown_attribute`] and [`skip_named_meta_item`] when
+/// Callers will usually want to use [`check_unknown_attribute`] and [`skip_meta_item`] when
 /// encountering any unknown fields.
 ///
 /// Returns [`Err`] on any parsing errors or the first failure of `func`.
@@ -541,7 +541,7 @@ where
 ///
 /// Consumes all tokens up until the comma. Does not consume the comma.
 #[inline]
-pub fn skip_named_meta_item(input: ParseStream) {
+pub fn skip_meta_item(input: ParseStream) {
     input
         .step(|cursor| {
             let mut cur = *cursor;

--- a/core/parse_helpers.rs
+++ b/core/parse_helpers.rs
@@ -787,6 +787,14 @@ pub fn inputs_span<'s, S: Borrow<ParseBuffer<'s>>>(inputs: &[S]) -> Span {
     }
 }
 
+/// Returns an error with a "missing required field" message.
+///
+/// The error will be spanned to `span`.
+#[inline]
+pub fn missing_field_error(name: &str, span: Span) -> Error {
+    syn::Error::new(span, format_args!("missing required field {name}"))
+}
+
 /// Returns an error with a "unexpected flag" message.
 ///
 /// The error will be spanned to `span`.

--- a/core/parse_meta.rs
+++ b/core/parse_meta.rs
@@ -127,6 +127,17 @@ pub trait ParseMetaItem: Sized {
     fn parse_meta_item_named(input: ParseStream, span: Span) -> Result<Self> {
         parse_named_meta_item(input, span)
     }
+    /// Fallback for when a required item is missing.
+    ///
+    /// Only called when a required (non-default) field was omitted from a parsed attribute.
+    /// Implementations on types that implement [`Default`] will most likely want to return
+    /// <code>[Ok]\([Default::default]\(\)\)</code> here.
+    ///
+    /// The default implementation returns an error.
+    #[inline]
+    fn missing_meta_item(name: &str, span: Span) -> Result<Self> {
+        Err(missing_field_error(name, span))
+    }
 }
 
 /// Parses a meta item for a structure with unnamed fields.
@@ -350,6 +361,10 @@ impl<T: ParseMetaItem> ParseMetaItem for Option<T> {
     #[inline]
     fn parse_meta_item_flag(span: Span) -> Result<Self> {
         T::parse_meta_item_flag(span).map(Some)
+    }
+    #[inline]
+    fn missing_meta_item(_name: &str, _span: Span) -> Result<Self> {
+        Ok(None)
     }
 }
 

--- a/core/parse_meta.rs
+++ b/core/parse_meta.rs
@@ -221,7 +221,7 @@ pub trait ParseMetaAppend: Sized {
     /// Parse the item from a group of inline named contexts.
     ///
     /// Fields with names matching any path in `paths` will be appended. Non-matching fields should
-    /// be skipped with [`crate::parse_helpers::skip_named_meta_item`].
+    /// be skipped with [`crate::parse_helpers::skip_meta_item`].
     fn parse_meta_append<'s, S, I, P>(inputs: &[S], paths: I) -> Result<Self>
     where
         S: Borrow<ParseBuffer<'s>>,
@@ -238,7 +238,7 @@ pub trait ParseMetaRest: Sized {
     /// Parse the item from a group of inline named contexts.
     ///
     /// Fields with names in `exclude` should be should be skipped with
-    /// [`crate::parse_helpers::skip_named_meta_item`].
+    /// [`crate::parse_helpers::skip_meta_item`].
     fn parse_meta_rest<'s, S: Borrow<ParseBuffer<'s>>>(
         inputs: &[S],
         exclude: &[&str],
@@ -468,7 +468,7 @@ macro_rules! impl_parse_meta_item_collection {
                         let $item = <_>::parse_meta_item_named(input, pspan)?;
                         $push;
                     } else {
-                        skip_named_meta_item(input);
+                        skip_meta_item(input);
                     }
                     Ok(())
                 })?;
@@ -549,7 +549,7 @@ macro_rules! impl_parse_meta_item_set {
                             errors.push(span, "Duplicate key");
                         }
                     } else {
-                        skip_named_meta_item(input);
+                        skip_meta_item(input);
                     }
                     Ok(())
                 })?;
@@ -631,7 +631,7 @@ macro_rules! impl_parse_meta_item_map {
                         let start = input.span();
                         let $key = $kp::parse_meta_item(input, ParseMode::Unnamed)?;
                         if exclude.contains(&path_to_string($key.borrow()).as_str()) {
-                            skip_named_meta_item(input);
+                            skip_meta_item(input);
                         } else {
                             let span = input.span().join(start).unwrap();
                             let $value = <_>::parse_meta_item_named(input, start)?;

--- a/core/util.rs
+++ b/core/util.rs
@@ -22,6 +22,7 @@ pub type Result<T> = syn::Result<T>;
 #[derive(Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct Errors {
+    // RefCell here so this can be re-entrant when used from parser combinators
     errors: RefCell<Option<Error>>,
 }
 

--- a/core/util.rs
+++ b/core/util.rs
@@ -288,7 +288,7 @@ impl<T: ParseMetaItem> ParseMetaItem for SpannedValue<T> {
     fn parse_meta_item(input: ParseStream, mode: crate::ParseMode) -> Result<Self> {
         let span = input.span();
         let value = T::parse_meta_item(input, mode)?;
-        let span = input.span().join(span).unwrap();
+        let span = input.span().join(span).unwrap_or(span);
         Ok(Self { value, span })
     }
     #[inline]
@@ -309,6 +309,12 @@ impl<T: ParseMetaItem> ParseMetaItem for SpannedValue<T> {
             value: T::parse_meta_item_flag(span)?,
             span,
         })
+    }
+    #[inline]
+    fn parse_meta_item_named(input: ParseStream, span: Span) -> Result<Self> {
+        let value = T::parse_meta_item_named(input, span)?;
+        let span = input.span().join(span).unwrap_or(span);
+        Ok(Self { value, span })
     }
 }
 

--- a/core/util.rs
+++ b/core/util.rs
@@ -420,6 +420,10 @@ impl<T> DerefMut for SpannedValue<T> {
 /// Similar to an <code>[Option]&lt;[SpannedValue]&lt;[bool]>></code> but does not allow `=` or
 /// `()` after the field name. Thus, it is only useful with named fields. Parsing this out of a
 /// tuple struct or tuple variant will always result in a parse error.
+///
+/// It is not necessary to use [`#[deluxe(default)]`](ParseMetaItem#deluxedefault-1) on a field
+/// using this type. The field will automatically be created with a `false` value if the name is
+/// omitted.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Flag(Option<Span>);
 
@@ -516,5 +520,9 @@ impl ParseMetaItem for Flag {
         } else {
             Err(Error::new(input.span(), "unexpected token"))
         }
+    }
+    #[inline]
+    fn missing_meta_item(_name: &str, _span: Span) -> Result<Self> {
+        Ok(Self::unset())
     }
 }

--- a/core/validations.rs
+++ b/core/validations.rs
@@ -7,13 +7,14 @@ use crate::Errors;
 /// `attrs` should provide an iterator of tuples containing the field name, and an [`Option`]
 /// possibly containing the field value. If two or more are [`Some`], an error will be appended to
 /// `errors`, with `prefix` prepended onto the names.
-pub fn only_one<'t, I>(attrs: I, prefix: &str, errors: &Errors)
+pub fn only_one<'t, I, O>(attrs: I, prefix: &str, errors: &Errors)
 where
-    I: IntoIterator<Item = &'t (&'static str, Option<&'t dyn syn::spanned::Spanned>)>,
+    I: IntoIterator<Item = &'t (&'static str, O)>,
     I::IntoIter: Clone,
+    O: Into<Option<&'t dyn syn::spanned::Spanned>> + Clone + ?Sized + 't,
 {
     let iter = attrs.into_iter();
-    let present_spans = iter.clone().filter_map(|f| f.1);
+    let present_spans = iter.clone().filter_map(|f| f.1.clone().into());
     if present_spans.clone().take(2).count() == 2 {
         let mut names = String::new();
         for (n, _) in iter {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deluxe-macros"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Derive macros for Deluxe procedural macro attribute parser"
 license = "MIT"
@@ -19,4 +19,4 @@ proc-macro2 = "1.0.38"
 proc-macro-crate = "1.1.3"
 quote = "1.0.18"
 syn = { version = "1.0.96", features = ["full", "parsing"], default-features = false }
-deluxe-core = { path = "../core", version = "0.2.0" }
+deluxe-core = { path = "../core", version = "0.3.0" }

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -4,6 +4,7 @@
 //! crate for an overview.
 
 #![deny(missing_docs)]
+#![deny(unsafe_code)]
 
 #[macro_use]
 mod util;

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -253,6 +253,10 @@ pub fn derive_parse_attributes(item: TokenStream) -> TokenStream {
 ///
 ///   Initializes the field with the value of [`Default::default`] if the field is omitted.
 ///
+///   It is not necessary to use this on fields of type [`Option`] or [`Flag`](deluxe_core::Flag),
+///   or any other type that has a top-level [`#[deluxe(default)]`](#deluxedefault) on the type
+///   itself.
+///
 /// - ##### `#[deluxe(default = expr)]`
 ///
 ///   Initializes the field with the value of `expr` if the field is omitted. The expression will
@@ -320,10 +324,11 @@ pub fn derive_parse_attributes(item: TokenStream) -> TokenStream {
 ///   path to a type containing associated functions.
 ///
 ///   The functions will be called as `module::parse_meta_item`, `module::parse_meta_item_inline`,
-///   `module::parse_meta_item_flag`, and `module::parse_meta_item_named`. All four functions must
-///   be implemented, even if just to return an error. The signatures of these functions should
-///   match the equivalent functions in [`ParseMetaItem`](crate::ParseMetaItem), although they can
-///   be generic over the return type. Fields using this attribute are not required to implement
+///   `module::parse_meta_item_flag`, `module::parse_meta_item_named`, and
+///   `module::missing_meta_item`. All five functions must be implemented, even if just to return
+///   an error. The signatures of these functions should match the equivalent functions in
+///   [`ParseMetaItem`](crate::ParseMetaItem), although they can be generic over the return type.
+///   Fields using this attribute are not required to implement
 ///   [`ParseMetaItem`](crate::ParseMetaItem).
 ///
 ///   `parse_meta_item_inline` implementations can call

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -160,6 +160,32 @@ pub fn derive_parse_attributes(item: TokenStream) -> TokenStream {
 ///   definitions to use [`flatten`](#deluxeflatten-1), [`append`](#deluxeappend) or
 ///   [`rest`](#deluxerest) on this type.
 ///
+/// - ##### `#[deluxe(and_then = expr)]`
+///
+///   Executes an additional function ater parsing to perform additional transformations or
+///   validation on the input.
+///
+///   This attribute is a simple wrapper around
+///   [`Result::and_then`](deluxe_core::Result::and_then). The function returned by `expr` must
+///   conform to the signature <code>fn(T) -> [deluxe::Result](deluxe_core::Result)&lt;T></code>
+///   where `T` is the type of the struct/enum being parsed. Returning
+///   [`Err`](deluxe_core::Result::Err) will cause the entire parse to fail.
+///
+///   This attribute can be specified multiple times. When multiple `and_then` attributes are
+///   present, Deluxe will execute each function in order the attributs were specified.
+///
+///   ```ignore
+///   #[derive(deluxe::ParseMetaItem)]
+///   #[deluxe(and_then = Self::validate)]
+///   struct Data(i32);
+///   impl Data {
+///       fn validate(self) -> deluxe::Result<Self> {
+///           // ... perform some checks here ...
+///           Ok(self)
+///       }
+///   }
+///   ```
+///
 /// - ##### `#[deluxe(allow_unknown_fields)]`
 ///
 ///   Ignore any tokens and do not generate an error when an unknown field is encountered.

--- a/macros/parse_attributes.rs
+++ b/macros/parse_attributes.rs
@@ -268,7 +268,7 @@ pub fn impl_parse_attributes(input: syn::DeriveInput, errors: &Errors, mode: Mod
     });
 
     // value types must be copied into the structure
-    if !container_is_ref {
+    if container_field.is_some() && !container_is_ref {
         let where_clause = generics.make_where_clause();
         where_clause.predicates.push(syn::parse_quote! {
             #container_ty: #priv_::Clone

--- a/macros/parse_attributes.rs
+++ b/macros/parse_attributes.rs
@@ -37,14 +37,9 @@ fn impl_for_struct<'i>(
     mode: Mode,
     errors: &Errors,
 ) -> Option<AttrImpl<'i>> {
-    let struct_attr =
-        match <Struct as deluxe_core::ParseAttributes<syn::DeriveInput>>::parse_attributes(input) {
-            Ok(s) => Some(s),
-            Err(err) => {
-                errors.push_syn(err);
-                None
-            }
-        };
+    let struct_attr = errors.push_result(<Struct as deluxe_core::ParseAttributes<
+        syn::DeriveInput,
+    >>::parse_attributes(input));
 
     let crate_path = super::get_crate_path(struct_attr.as_ref().map(|s| s.crate_.clone()), errors)?;
     let crate_ = &crate_path;
@@ -122,14 +117,9 @@ fn impl_for_enum<'i>(
     mode: Mode,
     errors: &Errors,
 ) -> Option<AttrImpl<'i>> {
-    let enum_attr =
-        match <Enum as deluxe_core::ParseAttributes<syn::DeriveInput>>::parse_attributes(input) {
-            Ok(e) => Some(e),
-            Err(err) => {
-                errors.push_syn(err);
-                None
-            }
-        };
+    let enum_attr = errors.push_result(
+        <Enum as deluxe_core::ParseAttributes<syn::DeriveInput>>::parse_attributes(input),
+    );
 
     let crate_path = super::get_crate_path(enum_attr.as_ref().map(|e| e.crate_.clone()), errors)?;
     let crate_ = &crate_path;

--- a/macros/parse_attributes.rs
+++ b/macros/parse_attributes.rs
@@ -335,6 +335,10 @@ pub fn impl_parse_attributes(input: syn::DeriveInput, errors: &Errors, mode: Mod
         Mode::Parse => None,
         Mode::Extract => Some(quote_mixed! { ? }),
     };
+    let path_name_unwrap = attributes.first().map(|path| {
+        let path = deluxe_core::parse_helpers::path_to_string(path);
+        quote_mixed! { .or(#priv_::Option::Some(#path)) }
+    });
 
     quote_mixed! {
         impl #impl_generics #trait_ for #ident #type_generics #where_clause {
@@ -347,6 +351,7 @@ pub fn impl_parse_attributes(input: syn::DeriveInput, errors: &Errors, mode: Mod
                     #priv_::parse_helpers::#get_tokens::<Self, _>(obj) #tokens_try,
                     |inputs, spans| {
                         let span = #priv_::parse_helpers::first_span(spans);
+                        let path_name = #priv_::parse_helpers::first_path_name(spans) #path_name_unwrap;
                         let _mode = #crate_::ParseMode::Named(span);
                         #parse
                     }

--- a/macros/parse_meta_item.rs
+++ b/macros/parse_meta_item.rs
@@ -9,6 +9,7 @@ struct MetaDef {
     pub parse: TokenStream,
     pub inline: Option<TokenStream>,
     pub flag: Option<TokenStream>,
+    pub default: Option<syn::Expr>,
     pub extra: Option<TokenStream>,
     pub crate_path: syn::Path,
     pub priv_path: syn::Path,
@@ -198,10 +199,14 @@ fn impl_for_struct(
         }
         _ => {}
     }
+    let default = struct_attr
+        .and_then(|s| s.default)
+        .map(|d| d.to_expr(&syn::parse_quote! { Self }, priv_).into_owned());
     Some(MetaDef {
         parse,
         inline,
         flag,
+        default,
         extra,
         crate_path,
         priv_path,
@@ -269,6 +274,9 @@ fn impl_for_enum(input: &syn::DeriveInput, errors: &Errors) -> Option<MetaDef> {
         flag: Some(quote_mixed! {
             #priv_::parse_helpers::parse_empty_meta_item(span, #crate_::ParseMode::Named(span))
         }),
+        default: enum_attr
+            .and_then(|s| s.default)
+            .map(|d| d.to_expr(&syn::parse_quote! { Self }, priv_).into_owned()),
         extra: Some(quote_mixed! {
             impl #impl_generics #crate_::ParseMetaFlatNamed for #enum_ident #type_generics #where_clause {
                 #[inline]
@@ -329,6 +337,7 @@ pub fn impl_parse_meta_item(input: syn::DeriveInput, errors: &Errors) -> TokenSt
         parse,
         inline,
         flag,
+        default,
         extra,
         crate_path: crate_,
         priv_path: priv_,
@@ -362,6 +371,14 @@ pub fn impl_parse_meta_item(input: syn::DeriveInput, errors: &Errors) -> TokenSt
             }
         }
     });
+    let missing = default.map(|default| {
+        quote_mixed! {
+            #[inline]
+            fn missing_meta_item(name: &#priv_::str, span: #priv_::Span) -> #crate_::Result<Self> {
+                #crate_::Result::Ok(#default)
+            }
+        }
+    });
     quote_mixed! {
         impl #impl_generics #crate_::ParseMetaItem for #ident #type_generics #where_clause {
             #[inline]
@@ -373,6 +390,7 @@ pub fn impl_parse_meta_item(input: syn::DeriveInput, errors: &Errors) -> TokenSt
             }
             #inline
             #flag
+            #missing
         }
         #extra
     }

--- a/macros/parse_meta_item.rs
+++ b/macros/parse_meta_item.rs
@@ -20,14 +20,9 @@ fn impl_for_struct(
     struct_: &syn::DataStruct,
     errors: &Errors,
 ) -> Option<MetaDef> {
-    let mut struct_attr =
-        match <Struct as deluxe_core::ParseAttributes<syn::DeriveInput>>::parse_attributes(input) {
-            Ok(s) => Some(s),
-            Err(err) => {
-                errors.push_syn(err);
-                None
-            }
-        };
+    let mut struct_attr = errors.push_result(<Struct as deluxe_core::ParseAttributes<
+        syn::DeriveInput,
+    >>::parse_attributes(input));
 
     let crate_path = super::get_crate_path(struct_attr.as_ref().map(|s| s.crate_.clone()), errors)?;
     let crate_ = &crate_path;
@@ -215,14 +210,9 @@ fn impl_for_struct(
 
 #[inline]
 fn impl_for_enum(input: &syn::DeriveInput, errors: &Errors) -> Option<MetaDef> {
-    let enum_attr =
-        match <Enum as deluxe_core::ParseAttributes<syn::DeriveInput>>::parse_attributes(input) {
-            Ok(e) => Some(e),
-            Err(err) => {
-                errors.push_syn(err);
-                None
-            }
-        };
+    let enum_attr = errors.push_result(
+        <Enum as deluxe_core::ParseAttributes<syn::DeriveInput>>::parse_attributes(input),
+    );
 
     let crate_path = super::get_crate_path(enum_attr.as_ref().map(|e| e.crate_.clone()), errors)?;
     let crate_ = &crate_path;

--- a/macros/types/enum.rs
+++ b/macros/types/enum.rs
@@ -190,7 +190,7 @@ impl<'e> ParseAttributes<'e, syn::DeriveInput> for Enum<'e> {
                         "and_then" => {
                             match errors.push_result(<_>::parse_meta_item_named(input, span)) {
                                 Some(e) => and_thens.push(e),
-                                None => parse_helpers::skip_named_meta_item(input),
+                                None => parse_helpers::skip_meta_item(input),
                             }
                         }
                         "attributes" => {
@@ -198,7 +198,7 @@ impl<'e> ParseAttributes<'e, syn::DeriveInput> for Enum<'e> {
                                 .push_result(mod_path_vec::parse_meta_item_named(input, span))
                             {
                                 Some(attrs) => attributes.extend(attrs.into_iter()),
-                                None => parse_helpers::skip_named_meta_item(input),
+                                None => parse_helpers::skip_meta_item(input),
                             }
                         }
                         "allow_unknown_fields" => allow_unknown_fields.parse_named_item(
@@ -214,7 +214,7 @@ impl<'e> ParseAttributes<'e, syn::DeriveInput> for Enum<'e> {
                                 Self::field_names(),
                                 &errors,
                             );
-                            parse_helpers::skip_named_meta_item(input);
+                            parse_helpers::skip_meta_item(input);
                         }
                     }
                     Ok(())

--- a/macros/types/field.rs
+++ b/macros/types/field.rs
@@ -919,25 +919,21 @@ impl<'f> Field<'f> {
                 )
             }
             syn::Fields::Unit => {
-                let variant = match target {
-                    ParseTarget::Init(variant) => variant,
-                    _ => None,
-                }
-                .into_iter();
-                let variant2 = variant.clone();
                 let inline = if mode == TokenMode::ParseMetaItem {
                     quote_mixed! {
+                        #pre
                         <() as #crate_::ParseMetaItem>::parse_meta_item_inline(inputs, _mode)?;
-                        #crate_::Result::Ok(Self #(::#variant)*)
+                        #post
                     }
                 } else {
                     quote_mixed! {
+                        #pre
                         for input in inputs {
                             #priv_::parse_helpers::parse_eof_or_trailing_comma(
                                 #priv_::Borrow::borrow(input),
                             )?;
                         }
-                        #crate_::Result::Ok(Self #(::#variant)*)
+                        #post
                     }
                 };
                 (
@@ -951,7 +947,8 @@ impl<'f> Field<'f> {
                     },
                     Some(inline),
                     Some(quote_mixed! {
-                        #crate_::Result::Ok(Self #(::#variant2)*)
+                        #pre
+                        #post
                     }),
                 )
             }

--- a/macros/types/field.rs
+++ b/macros/types/field.rs
@@ -95,7 +95,7 @@ impl ParseMetaItem for FieldFlatten {
                 ),
                 _ => {
                     errors.push_syn(parse_helpers::unknown_error(path, span, &["prefix"]));
-                    parse_helpers::skip_named_meta_item(input);
+                    parse_helpers::skip_meta_item(input);
                 }
             }
             Ok(())
@@ -167,7 +167,7 @@ impl ParseMetaItem for FieldContainer {
                         span,
                         &["lifetime", "ty"],
                     ));
-                    parse_helpers::skip_named_meta_item(input);
+                    parse_helpers::skip_meta_item(input);
                 }
             }
             Ok(())
@@ -844,7 +844,7 @@ impl<'f> Field<'f> {
                                     #(#field_matches)*
                                     _ => {
                                         #validate
-                                        #priv_::parse_helpers::skip_named_meta_item(input);
+                                        #priv_::parse_helpers::skip_meta_item(input);
                                     }
                                 }
                                 #crate_::Result::Ok(())
@@ -1007,7 +1007,7 @@ impl<'f> ParseAttributes<'f, syn::Field> for Field<'f> {
                         "append" => {
                             if !named {
                                 errors.push(span, "`append` not allowed on tuple struct field");
-                                parse_helpers::skip_named_meta_item(input);
+                                parse_helpers::skip_meta_item(input);
                             } else {
                                 append.parse_named_item("append", input, span, &errors);
                             }
@@ -1015,7 +1015,7 @@ impl<'f> ParseAttributes<'f, syn::Field> for Field<'f> {
                         "rest" => {
                             if !named {
                                 errors.push(span, "`rest` not allowed on tuple struct field");
-                                parse_helpers::skip_named_meta_item(input);
+                                parse_helpers::skip_meta_item(input);
                             } else {
                                 rest.parse_named_item("rest", input, span, &errors);
                             }
@@ -1071,7 +1071,7 @@ impl<'f> ParseAttributes<'f, syn::Field> for Field<'f> {
                                             }
                                         }
                                     }
-                                    None => parse_helpers::skip_named_meta_item(input),
+                                    None => parse_helpers::skip_meta_item(input),
                                 }
                             }
                         }
@@ -1086,7 +1086,7 @@ impl<'f> ParseAttributes<'f, syn::Field> for Field<'f> {
                                 Self::field_names(),
                                 &errors,
                             );
-                            parse_helpers::skip_named_meta_item(input);
+                            parse_helpers::skip_meta_item(input);
                         }
                     }
                     Ok(())

--- a/macros/types/struct.rs
+++ b/macros/types/struct.rs
@@ -73,7 +73,7 @@ impl ParseMetaItem for StructTransparent {
                         span,
                         &["flatten_named", "flatten_unnamed", "append", "rest"],
                     ));
-                    parse_helpers::skip_named_meta_item(input);
+                    parse_helpers::skip_meta_item(input);
                 }
             }
             Ok(())
@@ -452,7 +452,7 @@ impl<'s> ParseAttributes<'s, syn::DeriveInput> for Struct<'s> {
                                     span,
                                     "`allow_unknown_fields` not allowed on tuple struct",
                                 );
-                                parse_helpers::skip_named_meta_item(input);
+                                parse_helpers::skip_meta_item(input);
                             } else {
                                 allow_unknown_fields.parse_named_item(
                                     "allow_unknown_fields",
@@ -465,7 +465,7 @@ impl<'s> ParseAttributes<'s, syn::DeriveInput> for Struct<'s> {
                         "default" => {
                             if matches!(struct_.fields, syn::Fields::Unit) {
                                 errors.push(span, "`default` not allowed on unit struct");
-                                parse_helpers::skip_named_meta_item(input);
+                                parse_helpers::skip_meta_item(input);
                             } else {
                                 default.parse_named_item("default", input, span, &errors);
                             }
@@ -474,7 +474,7 @@ impl<'s> ParseAttributes<'s, syn::DeriveInput> for Struct<'s> {
                         "and_then" => {
                             match errors.push_result(<_>::parse_meta_item_named(input, span)) {
                                 Some(e) => and_thens.push(e),
-                                None => parse_helpers::skip_named_meta_item(input),
+                                None => parse_helpers::skip_meta_item(input),
                             }
                         }
                         "attributes" => {
@@ -482,7 +482,7 @@ impl<'s> ParseAttributes<'s, syn::DeriveInput> for Struct<'s> {
                                 .push_result(mod_path_vec::parse_meta_item_named(input, span))
                             {
                                 Some(attrs) => attributes.extend(attrs.into_iter()),
-                                None => parse_helpers::skip_named_meta_item(input),
+                                None => parse_helpers::skip_meta_item(input),
                             }
                         }
                         _ => {
@@ -492,7 +492,7 @@ impl<'s> ParseAttributes<'s, syn::DeriveInput> for Struct<'s> {
                                 Self::field_names(),
                                 &errors,
                             );
-                            parse_helpers::skip_named_meta_item(input);
+                            parse_helpers::skip_meta_item(input);
                         }
                     }
                     Ok(())

--- a/macros/types/variant.rs
+++ b/macros/types/variant.rs
@@ -93,7 +93,7 @@ impl<'v> Variant<'v> {
                         value = #priv_::FieldStatus::Some(v);
                     }
                 } else {
-                    #priv_::parse_helpers::skip_named_meta_item(input);
+                    #priv_::parse_helpers::skip_meta_item(input);
                     if value.is_none() {
                         value = #priv_::FieldStatus::ParseError;
                     }
@@ -149,7 +149,7 @@ impl<'v> Variant<'v> {
                                 #priv_::parse_helpers::check_unknown_attribute(
                                     p, span, allowed, &errors,
                                 );
-                                #priv_::parse_helpers::skip_named_meta_item(input);
+                                #priv_::parse_helpers::skip_meta_item(input);
                                 #crate_::Result::Ok(())
                             },
                         );
@@ -215,7 +215,7 @@ impl<'v> Variant<'v> {
                 if let #priv_::Option::Some(v) = errors.push_result(res) {
                     value = #priv_::FieldStatus::Some(v);
                 } else {
-                    #priv_::parse_helpers::skip_named_meta_item(input);
+                    #priv_::parse_helpers::skip_meta_item(input);
                     if value.is_none() {
                         value = #priv_::FieldStatus::ParseError;
                     }
@@ -369,7 +369,7 @@ impl<'v> Variant<'v> {
                 if validate {
                     let _ = #priv_::parse_helpers::parse_struct(inputs, |input, p, span| {
                         #priv_::parse_helpers::check_unknown_attribute(p, span, allowed, &errors);
-                        #priv_::parse_helpers::skip_named_meta_item(input);
+                        #priv_::parse_helpers::skip_meta_item(input);
                         #crate_::Result::Ok(())
                     });
                 }
@@ -443,7 +443,7 @@ impl<'v> Variant<'v> {
                 match cur {
                     #(#variant_matches)*
                     _ => {
-                        #priv_::parse_helpers::skip_named_meta_item(input);
+                        #priv_::parse_helpers::skip_meta_item(input);
                     }
                 }
                 #crate_::Result::Ok(())
@@ -557,7 +557,7 @@ impl<'v> ParseAttributes<'v, syn::Variant> for Variant<'v> {
                                     span,
                                     "`allow_unknown_fields` not allowed on tuple variant",
                                 );
-                                parse_helpers::skip_named_meta_item(input);
+                                parse_helpers::skip_meta_item(input);
                             } else {
                                 allow_unknown_fields.parse_named_item(
                                     "allow_unknown_fields",
@@ -610,7 +610,7 @@ impl<'v> ParseAttributes<'v, syn::Variant> for Variant<'v> {
                                         }
                                     }
                                 }
-                                None => parse_helpers::skip_named_meta_item(input),
+                                None => parse_helpers::skip_meta_item(input),
                             }
                         }
                         "skip" => skip.parse_named_item("skip", input, span, &errors),
@@ -621,7 +621,7 @@ impl<'v> ParseAttributes<'v, syn::Variant> for Variant<'v> {
                                 Self::field_names(),
                                 &errors,
                             );
-                            parse_helpers::skip_named_meta_item(input);
+                            parse_helpers::skip_meta_item(input);
                         }
                     }
                     Ok(())

--- a/macros/types/variant.rs
+++ b/macros/types/variant.rs
@@ -257,6 +257,7 @@ impl<'v> Variant<'v> {
         crate_: &syn::Path,
         mode: TokenMode,
         target: Option<&syn::Expr>,
+        and_thens: &[syn::Expr],
         allow_unknown_fields: bool,
     ) -> TokenStream {
         let priv_path: syn::Path = syn::parse_quote! { #crate_::____private };
@@ -454,6 +455,11 @@ impl<'v> Variant<'v> {
                 #(#flat_matches else)*
                 #empty_match
             }
+            let value = value.into_option();
+            #(let value = value.and_then(|v| {
+                let f = #and_thens;
+                errors.push_result(f(v))
+            });)*
             errors.check()?;
             #crate_::Result::Ok(value.unwrap())
         }

--- a/macros/types/variant.rs
+++ b/macros/types/variant.rs
@@ -1,5 +1,8 @@
 use super::*;
-use deluxe_core::{parse_helpers, ParseAttributes, ParseMetaItem, Result, SpannedValue};
+use deluxe_core::{
+    parse_helpers::{self, FieldStatus},
+    ParseAttributes, ParseMetaItem, Result, SpannedValue,
+};
 use proc_macro2::{Span, TokenStream};
 use quote::quote_spanned;
 use std::collections::{BTreeMap, BTreeSet};
@@ -80,17 +83,19 @@ impl<'v> Variant<'v> {
                 .unwrap();
             return quote_mixed! {
                 #pre
-                match #crate_::ParseMetaItem::parse_meta_item_named(input, span)
-                    .and_then(|v| {
-                        #name = #priv_::Option::Some(v);
+                if let #priv_::Option::Some(v) = errors.push_result(
+                    #crate_::ParseMetaItem::parse_meta_item_named(input, span).and_then(|v| {
+                        #name = #priv_::FieldStatus::Some(v);
                         #post
                     })
-                {
-                    #crate_::Result::Ok(v) => {
-                        value = #priv_::Option::Some(v);
+                ) {
+                    if !value.is_some() {
+                        value = #priv_::FieldStatus::Some(v);
                     }
-                    #crate_::Result::Err(err) => {
-                        errors.push_syn(err);
+                } else {
+                    #priv_::parse_helpers::skip_named_meta_item(input);
+                    if value.is_none() {
+                        value = #priv_::FieldStatus::ParseError;
                     }
                 }
             };
@@ -135,7 +140,10 @@ impl<'v> Variant<'v> {
             let validate_empty = match flat {
                 FlatMode::Empty { all_keys } if !allow_unknown_fields => Some(quote_mixed! {
                     if validate {
-                        #priv_::parse_helpers::parse_struct(
+                        if !errors.is_empty() {
+                            return #crate_::Result::Err(errors.check().unwrap_err());
+                        }
+                        let _ = #priv_::parse_helpers::parse_struct(
                             &#priv_::parse_helpers::fork_inputs(inputs),
                             |input, p, span| {
                                 #priv_::parse_helpers::check_unknown_attribute(
@@ -144,7 +152,7 @@ impl<'v> Variant<'v> {
                                 #priv_::parse_helpers::skip_named_meta_item(input);
                                 #crate_::Result::Ok(())
                             },
-                        )?;
+                        );
                         if !errors.is_empty() {
                             #priv_::parse_helpers::variant_required(
                                 span,
@@ -170,13 +178,10 @@ impl<'v> Variant<'v> {
                     #unset_validate
                     #inline
                 })();
-                match ret {
-                    #crate_::Result::Ok(v) => {
-                        value = #priv_::Option::Some(v);
-                    }
-                    #crate_::Result::Err(err) => {
-                        errors.push_syn(err);
-                    }
+                if let #priv_::Option::Some(v) = errors.push_result(ret) {
+                    value = #priv_::FieldStatus::Some(v);
+                } else if value.is_none() {
+                    value = #priv_::FieldStatus::ParseError;
                 }
             }
         } else {
@@ -207,12 +212,12 @@ impl<'v> Variant<'v> {
                     },
                     #crate_::Result::Err(e) => #crate_::Result::Err(e),
                 };
-                match res {
-                    #crate_::Result::Ok(v) => {
-                        value = #priv_::Option::Some(v);
-                    }
-                    #crate_::Result::Err(err) => {
-                        errors.push_syn(err);
+                if let #priv_::Option::Some(v) = errors.push_result(res) {
+                    value = #priv_::FieldStatus::Some(v);
+                } else {
+                    #priv_::parse_helpers::skip_named_meta_item(input);
+                    if value.is_none() {
+                        value = #priv_::FieldStatus::ParseError;
                     }
                 }
             }
@@ -271,15 +276,16 @@ impl<'v> Variant<'v> {
                             (key, k),
                             &errors
                         );
-                    } else {
+                    }
+                    if key.is_none() {
                         match k {
                             #(#idents => {
                                 key = #priv_::Option::Some(#idents);
                             })*
                             _ => {}
                         }
-                        #parse
                     }
+                    #parse
                 },
             })
         });
@@ -383,7 +389,7 @@ impl<'v> Variant<'v> {
             if let Some(target) = target {
                 return quote_mixed! {
                     {
-                        value = #priv_::Option::Some(#target);
+                        value = #priv_::FieldStatus::Some(#target);
                     }
                 };
             }
@@ -423,10 +429,10 @@ impl<'v> Variant<'v> {
         let flat_matches = flat_matches.values();
         quote_mixed! {
             let mut key: #priv_::Option<&'static #priv_::str> = #priv_::Option::None;
-            let mut value = #priv_::Option::None;
+            let mut value = #priv_::FieldStatus::None;
             #(let mut #paths_ident = #priv_::HashMap::<#priv_::String, #priv_::Span>::new();)*
-            #priv_::parse_helpers::parse_struct(#inputs_expr, |input, p, span| {
-                let errors = #crate_::Errors::new();
+            let errors = #crate_::Errors::new();
+            errors.push_result(#priv_::parse_helpers::parse_struct(#inputs_expr, |input, p, span| {
                 let inputs = [input];
                 let inputs = inputs.as_slice();
                 let cur = p.strip_prefix(prefix);
@@ -439,14 +445,12 @@ impl<'v> Variant<'v> {
                         #priv_::parse_helpers::skip_named_meta_item(input);
                     }
                 }
-                errors.check()?;
                 #crate_::Result::Ok(())
-            })?;
-            let errors = #crate_::Errors::new();
+            }));
             if value.is_some() {
                 #(#disallow_flats)*
                 #validate
-            } else {
+            } else if value.is_none() {
                 #(#flat_matches else)*
                 #empty_match
             }
@@ -496,49 +500,49 @@ impl<'v> ParseAttributes<'v, syn::Variant> for Variant<'v> {
             parse_helpers::ref_tokens::<Self, _>(variant),
             |inputs, _| {
                 let errors = crate::Errors::new();
-                let mut alias_span = None;
+                let mut alias_span = FieldStatus::None;
                 let mut idents = Vec::new();
-                let mut flatten = None;
-                let mut rename = None;
-                let mut transparent = None;
-                let mut skip = None;
-                let mut allow_unknown_fields = None;
+                let mut flatten = FieldStatus::<Option<SpannedValue<bool>>>::None;
+                let mut rename = FieldStatus::None;
+                let mut transparent = FieldStatus::<Option<SpannedValue<bool>>>::None;
+                let mut skip = FieldStatus::None;
+                let mut allow_unknown_fields = FieldStatus::None;
                 let fields = variant
                     .fields
                     .iter()
-                    .filter_map(|f| match Field::parse_attributes(f) {
-                        Ok(f) => Some(f),
-                        Err(err) => {
-                            errors.push_syn(err);
-                            None
-                        }
-                    })
+                    .filter_map(|f| errors.push_result(Field::parse_attributes(f)))
                     .collect::<Vec<_>>();
-                parse_helpers::parse_struct(inputs, |input, path, span| {
+                errors.push_result(parse_helpers::parse_struct(inputs, |input, path, span| {
                     match path {
                         "transparent" => {
-                            if transparent.is_some() {
-                                errors.push(span, "duplicate attribute for `transparent`");
-                            }
-                            let mut iter = fields.iter().filter(|f| f.is_parsable());
-                            if let Some(first) = iter.next() {
-                                if iter.next().is_some() {
-                                    errors.push(
+                            transparent.parse_named_item_with(
+                                "transparent",
+                                input,
+                                span,
+                                &errors,
+                                |input, span| {
+                                    let mut iter = fields.iter().filter(|f| f.is_parsable());
+                                    if let Some(first) = iter.next() {
+                                        if first.flatten.as_ref().map(|f| f.value).unwrap_or(false)
+                                        {
+                                            return Err(syn::Error::new(
+                                                span,
+                                                "`transparent` variant field cannot be `flat`",
+                                            ));
+                                        } else if first.append.map(|v| *v).unwrap_or(false) {
+                                            return Err(syn::Error::new(
+                                                span,
+                                                "`transparent` variant field cannot be `append`",
+                                            ));
+                                        } else if iter.next().is_none() {
+                                            return <_>::parse_meta_item_named(input, span);
+                                        }
+                                    }
+                                    Err(syn::Error::new(
                                         span,
                                         "`transparent` variant must have only one parseable field",
-                                    );
-                                } else if first.flatten.as_ref().map(|f| f.value).unwrap_or(false) {
-                                    errors
-                                        .push(span, "`transparent` variant field cannot be `flat`");
-                                } else if first.append.map(|v| *v).unwrap_or(false) {
-                                    errors.push(
-                                        span,
-                                        "`transparent` variant field cannot be `append`",
-                                    );
-                                }
-                            }
-                            transparent = Some(
-                                <Option<SpannedValue<bool>>>::parse_meta_item_named(input, span)?,
+                                    ))
+                                },
                             );
                         }
                         "allow_unknown_fields" => {
@@ -547,53 +551,63 @@ impl<'v> ParseAttributes<'v, syn::Variant> for Variant<'v> {
                                     span,
                                     "`allow_unknown_fields` not allowed on tuple variant",
                                 );
+                                parse_helpers::skip_named_meta_item(input);
+                            } else {
+                                allow_unknown_fields.parse_named_item(
+                                    "allow_unknown_fields",
+                                    input,
+                                    span,
+                                    &errors,
+                                );
                             }
-                            if allow_unknown_fields.is_some() {
-                                errors.push(span, "duplicate attribute for `allow_unknown_fields`");
-                            }
-                            allow_unknown_fields =
-                                Some(ParseMetaItem::parse_meta_item_named(input, span)?);
                         }
-                        "flatten" => {
-                            if flatten.is_some() {
-                                errors.push(span, "duplicate attribute for `flatten`");
-                            }
-                            flatten = Some(<Option<SpannedValue<bool>>>::parse_meta_item_named(
-                                input, span,
-                            )?);
-                        }
+                        "flatten" => flatten.parse_named_item("flatten", input, span, &errors),
                         "rename" => {
-                            if rename.is_some() {
-                                errors.push(span, "duplicate attribute for `rename`");
-                            } else {
-                                rename = Some(span);
-                            }
-                            let name = <_>::parse_meta_item_named(input, span)?;
-                            if variant.ident == name {
-                                errors.push(span, "cannot rename field to its own name");
-                            } else if idents.contains(&name) {
-                                errors.push(span, format_args!("alias already given for `{name}`"));
-                            } else {
-                                idents.insert(0, name);
-                            }
+                            rename.parse_named_item_with(
+                                "rename",
+                                input,
+                                span,
+                                &errors,
+                                |input, span| {
+                                    let name = <_>::parse_meta_item_named(input, span)?;
+                                    if variant.ident == name {
+                                        Err(syn::Error::new(
+                                            span,
+                                            "cannot rename variant to its own name",
+                                        ))
+                                    } else if idents.contains(&name) {
+                                        Err(syn::Error::new(
+                                            span,
+                                            format_args!("alias already given for `{name}`"),
+                                        ))
+                                    } else {
+                                        idents.insert(0, name);
+                                        Ok(span)
+                                    }
+                                },
+                            );
                         }
                         "alias" => {
-                            let alias = <_>::parse_meta_item_named(input, span)?;
-                            if variant.ident == alias {
-                                errors.push(span, "cannot alias field to its own name");
-                            } else if idents.contains(&alias) {
-                                errors.push(span, format_args!("duplicate alias for `{alias}`"));
-                            } else {
-                                alias_span = Some(span);
-                                idents.push(alias);
+                            match errors.push_result(<_>::parse_meta_item_named(input, span)) {
+                                Some(alias) => {
+                                    if variant.ident == alias {
+                                        errors.push(span, "cannot alias variant to its own name");
+                                    } else if idents.contains(&alias) {
+                                        errors.push(
+                                            span,
+                                            format_args!("duplicate alias for `{alias}`"),
+                                        );
+                                    } else {
+                                        idents.push(alias);
+                                        if alias_span.is_none() {
+                                            alias_span = FieldStatus::Some(span);
+                                        }
+                                    }
+                                }
+                                None => parse_helpers::skip_named_meta_item(input),
                             }
                         }
-                        "skip" => {
-                            if skip.is_some() {
-                                errors.push(span, "duplicate attribute for `skip`");
-                            }
-                            skip = Some(ParseMetaItem::parse_meta_item_named(input, span)?);
-                        }
+                        "skip" => skip.parse_named_item("skip", input, span, &errors),
                         _ => {
                             parse_helpers::check_unknown_attribute(
                                 path,
@@ -605,7 +619,7 @@ impl<'v> ParseAttributes<'v, syn::Variant> for Variant<'v> {
                         }
                     }
                     Ok(())
-                })?;
+                }));
                 let transparent = transparent.flatten();
                 let flatten = flatten.flatten();
                 deluxe_core::only_one!("", &errors, flatten, rename);
@@ -660,10 +674,10 @@ impl<'v> ParseAttributes<'v, syn::Variant> for Variant<'v> {
                     variant,
                     fields,
                     idents: idents.into_iter().collect(),
-                    flatten: flatten.map(|v| *v),
-                    transparent: transparent.map(|v| *v),
-                    skip,
-                    allow_unknown_fields,
+                    flatten: flatten.map(|v| *v).into(),
+                    transparent: transparent.map(|v| *v).into(),
+                    skip: skip.into(),
+                    allow_unknown_fields: allow_unknown_fields.into(),
                 })
             },
         )

--- a/macros/util.rs
+++ b/macros/util.rs
@@ -3,14 +3,9 @@ use syn::parse::{Parse, Parser};
 
 use deluxe_core::Errors;
 
+#[inline]
 pub fn parse<T: Parse>(input: TokenStream, errors: &Errors) -> Option<T> {
-    match <T as Parse>::parse.parse2(input) {
-        Ok(t) => Some(t),
-        Err(e) => {
-            errors.push_syn(e);
-            None
-        }
-    }
+    errors.push_result(<T as Parse>::parse.parse2(input))
 }
 
 fn crate_path(errors: Option<&Errors>) -> Option<syn::Path> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,8 +612,8 @@ pub mod ____private {
 
 pub use deluxe_core::{
     define_with_collection, define_with_map, define_with_optional, parse_named_meta_item_with,
-    with, Error, Errors, ExtractAttributes, HasAttributes, ParseAttributes, ParseMetaItem,
-    ParseMode, Result,
+    validations, with, Error, Errors, ExtractAttributes, HasAttributes, ParseAttributes,
+    ParseMetaItem, ParseMode, Result, SpannedValue,
 };
 #[doc(hidden)]
 pub use deluxe_core::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ pub mod ____private {
 
 pub use deluxe_core::{
     define_with_collection, define_with_map, define_with_optional, parse_named_meta_item_with,
-    validations, with, Error, Errors, ExtractAttributes, HasAttributes, ParseAttributes,
+    validations, with, Error, Errors, ExtractAttributes, Flag, HasAttributes, ParseAttributes,
     ParseMetaItem, ParseMode, Result, SpannedValue,
 };
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,7 +587,7 @@
 
 #[doc(hidden)]
 pub mod ____private {
-    pub use deluxe_core::parse_helpers;
+    pub use deluxe_core::parse_helpers::{self, FieldStatus};
     pub use once_cell::sync::OnceCell as SyncOnceCell;
     pub use proc_macro2::Span;
     pub use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,6 +583,7 @@
 //! case, the container will be cloned into the structure.
 
 #![deny(missing_docs)]
+#![deny(unsafe_code)]
 
 #[doc(hidden)]
 pub mod ____private {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,7 +596,7 @@ pub mod ____private {
         collections::HashMap,
         convert::AsRef,
         default::Default,
-        format_args,
+        format, format_args,
         iter::IntoIterator,
         option::Option,
         primitive::{bool, str, usize},

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -11,12 +11,52 @@ use test_util::*;
 struct SingleAttribute(char);
 
 #[derive(::deluxe::ParseAttributes, ::deluxe::ExtractAttributes, PartialEq, Debug)]
+#[deluxe(attributes(single))]
+struct SingleAttributeNamed {
+    c: char,
+}
+
+#[derive(::deluxe::ParseAttributes, ::deluxe::ExtractAttributes, PartialEq, Debug)]
 #[deluxe(attributes(multi1, multi2))]
 struct MultiAttributes(char);
 
 #[test]
 fn multi_attributes() {
     use ::deluxe::HasAttributes;
+
+    let expr: ::syn::Expr = ::syn::parse2(q! { #[single('a')] true }).unwrap();
+    let m: SingleAttribute = ::deluxe::parse_attributes(&expr).unwrap();
+    ::std::assert_eq!(expr.attrs().len(), 1);
+    ::std::assert_eq!(m.0, 'a');
+
+    let expr: ::syn::Expr = ::syn::parse2(q! { #[single(c = 'a')] true }).unwrap();
+    let m: SingleAttributeNamed = ::deluxe::parse_attributes(&expr).unwrap();
+    ::std::assert_eq!(expr.attrs().len(), 1);
+    ::std::assert_eq!(m.c, 'a');
+
+    let expr: ::syn::Expr = ::syn::parse2(q! { true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, SingleAttribute>(&expr).unwrap_err_string(),
+        "missing required field 0 on #[single]"
+    );
+
+    let expr: ::syn::Expr = ::syn::parse2(q! { #[single] true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, SingleAttribute>(&expr).unwrap_err_string(),
+        "unexpected end of input, expected parentheses"
+    );
+
+    let expr: ::syn::Expr = ::syn::parse2(q! { true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, SingleAttributeNamed>(&expr).unwrap_err_string(),
+        "missing required field #[single(c)]"
+    );
+
+    let expr: ::syn::Expr = ::syn::parse2(q! { #[single] true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, SingleAttributeNamed>(&expr).unwrap_err_string(),
+        "unexpected end of input, expected parentheses"
+    );
 
     let expr: ::syn::Expr = ::syn::parse2(q! { #[multi1('a')] true }).unwrap();
     let m: MultiAttributes = ::deluxe::parse_attributes(&expr).unwrap();
@@ -31,7 +71,31 @@ fn multi_attributes() {
     let expr = ::syn::parse2(q! { true }).unwrap();
     ::std::assert_eq!(
         ::deluxe::parse_attributes::<::syn::Expr, MultiAttributes>(&expr).unwrap_err_string(),
-        "missing required field 0"
+        "missing required field 0 on #[multi1]"
+    );
+
+    let expr = ::syn::parse2(q! { #[multi1()] true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, MultiAttributes>(&expr).unwrap_err_string(),
+        "missing required field 0 on #[multi1]"
+    );
+
+    let expr = ::syn::parse2(q! { #[multi2()] true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, MultiAttributes>(&expr).unwrap_err_string(),
+        "missing required field 0 on #[multi2]"
+    );
+
+    let expr = ::syn::parse2(q! { #[multi2] true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, MultiAttributes>(&expr).unwrap_err_string(),
+        "unexpected end of input, expected parentheses"
+    );
+
+    let expr = ::syn::parse2(q! { #[multi3('c')] true }).unwrap();
+    ::std::assert_eq!(
+        ::deluxe::parse_attributes::<::syn::Expr, MultiAttributes>(&expr).unwrap_err_string(),
+        "missing required field 0 on #[multi1]"
     );
 
     let expr = ::syn::parse2(q! { #[multi2('c')] #[multi2('d')] true }).unwrap();

--- a/tests/attributes.rs
+++ b/tests/attributes.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 #![no_implicit_prelude]
 
 use ::quote::quote as q;

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -1642,3 +1642,70 @@ fn positional_and_named() {
         )
     );
 }
+
+#[derive(
+    ::deluxe::ParseAttributes,
+    ::deluxe::ExtractAttributes,
+    ::deluxe::ParseMetaItem,
+    PartialEq,
+    Debug,
+)]
+struct FlagStruct {
+    #[deluxe(default)]
+    myflag: ::deluxe::Flag,
+    #[deluxe(default)]
+    value: i32,
+}
+
+#[derive(
+    ::deluxe::ParseAttributes,
+    ::deluxe::ExtractAttributes,
+    ::deluxe::ParseMetaItem,
+    PartialEq,
+    Debug,
+)]
+// should always error when encountering the field
+struct FlagTupleStruct(::deluxe::Flag);
+
+#[test]
+fn flag() {
+    use ::std::prelude::v1::*;
+    let parse = parse_meta::<FlagStruct>;
+
+    ::std::assert_eq!(
+        parse(q! { { myflag } }).unwrap(),
+        FlagStruct {
+            myflag: true.into(),
+            value: 0,
+        }
+    );
+    ::std::assert_eq!(
+        parse(q! { {} }).unwrap(),
+        FlagStruct {
+            myflag: false.into(),
+            value: 0,
+        }
+    );
+    ::std::assert_eq!(
+        parse(q! { { myflag, value = 123 } }).unwrap(),
+        FlagStruct {
+            myflag: true.into(),
+            value: 123,
+        }
+    );
+    ::std::assert_eq!(
+        parse(q! { { myflag = true } }).unwrap_err_string(),
+        "unexpected token",
+    );
+    ::std::assert_eq!(
+        parse(q! { { myflag(true) } }).unwrap_err_string(),
+        "unexpected token",
+    );
+
+    let parse = parse_meta::<FlagTupleStruct>;
+
+    ::std::assert_eq!(
+        parse(q! { (myflag) }).unwrap_err_string(),
+        "field with type `Flag` can only be a named field with no value",
+    );
+}

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -707,7 +707,7 @@ struct StructWithTransparent {
     Debug,
 )]
 struct StructWithExtended {
-    #[deluxe(default, with = custom_int_option)]
+    #[deluxe(with = custom_int_option)]
     int: ::std::option::Option<i32>,
     #[deluxe(with = custom_int_vec)]
     int_vec: ::std::vec::Vec<i32>,
@@ -1671,7 +1671,6 @@ fn positional_and_named() {
     Debug,
 )]
 struct FlagStruct {
-    #[deluxe(default)]
     myflag: ::deluxe::Flag,
     #[deluxe(default)]
     value: i32,

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -162,6 +162,10 @@ fn parse_named() {
         parse(q! { {a(123), b("asdf"), a(456)} }).unwrap_err_string(),
         "duplicate attribute for `a`"
     );
+    ::std::assert_eq!(
+        parse(q! { {a(123), b("asdf"), a(456), a("456") } }).unwrap_err_string(),
+        "duplicate attribute for `a`, duplicate attribute for `a`, expected integer literal"
+    );
 }
 
 #[derive(
@@ -636,6 +640,14 @@ fn parse_simple_enum() {
     ::std::assert_eq!(parse(q! { { a } }).unwrap(), MySimpleEnum::A);
     ::std::assert_eq!(parse(q! { { b } }).unwrap(), MySimpleEnum::B);
     ::std::assert_eq!(parse(q! { { c } }).unwrap(), MySimpleEnum::C);
+    ::std::assert_eq!(
+        parse(q! { { a, b } }).unwrap_err_string(),
+        "expected only one enum variant, got `a` and `b`"
+    );
+    ::std::assert_eq!(
+        parse(q! { { a, c } }).unwrap_err_string(),
+        "expected only one enum variant, got `a` and `c`"
+    );
     ::std::assert_eq!(
         parse(q! { { d } }).unwrap_err_string(),
         "unknown field `d`, expected one of `a`, `b`, `c`"
@@ -1232,8 +1244,16 @@ fn enum_allow_unknown() {
         EnumAllow::Known { value: 50 }
     );
     ::std::assert_eq!(
+        parse(q! { { known(value(50)), unknown(value(51)) } }).unwrap_err_string(),
+        "expected only one enum variant, got `known` and `unknown`"
+    );
+    ::std::assert_eq!(
         parse(q! { { known(value(50), another("thing")) } }).unwrap_err_string(),
         "unknown field `another`"
+    );
+    ::std::assert_eq!(
+        parse(q! { { known(value(50), another("thing")), unknown(value("50")) } }).unwrap_err_string(),
+        "unknown field `another`, expected only one enum variant, got `known` and `unknown`, expected integer literal"
     );
     ::std::assert_eq!(
         parse(q! { { unknown(value(50)) } }).unwrap(),

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -1503,7 +1503,7 @@ impl ::deluxe::ParseMetaAppend for CustomAppendSum {
             if paths.clone().any(|path| path.as_ref() == p) {
                 value += ::deluxe_core::parse_helpers::parse_named_meta_item::<i32>(input, pspan)?;
             } else {
-                ::deluxe_core::parse_helpers::skip_named_meta_item(input);
+                ::deluxe_core::parse_helpers::skip_meta_item(input);
             }
             ::deluxe::Result::Ok(())
         })?;

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 #![no_implicit_prelude]
 
 use ::quote::quote as q;


### PR DESCRIPTION
Changelog:

- Added `Flag` type
- Added `_optional` parsing helpers
- Added `and_then` container attribute
- Implement `ToTokens` on `Errors`
- Improve generated parsers to accumulate more errors before returning
- Show the top-level attribute name in `ParseAttribute` missing field errors
- Remove requirement for `default` field attribute on `Option` and on types using `#[deluxe(default)]` on the type itself