### PR TITLE
Opinionated fix for failing to parse AngleBracketedGenericArguments

### DIFF
--- a/core/parse_helpers.rs
+++ b/core/parse_helpers.rs
@@ -13,9 +13,7 @@ pub use syn::{
     token::{Brace, Bracket, Paren},
 };
 use syn::{
-    parse::{ParseBuffer, ParseStream},
-    spanned::Spanned,
-    Token,
+    parse::{ParseBuffer, ParseStream}, spanned::Spanned, AngleBracketedGenericArguments, Expr, Token
 };
 
 /// Temporary container for storing parsing state for a single field.
@@ -599,25 +597,21 @@ where
     Ok(())
 }
 
-/// Skips over items in a [`ParseStream`](syn::parse::ParseStream) until a comma is reached.
-///
-/// Consumes all tokens up until the comma. Does not consume the comma.
+/// Skips over [`Expr`]s until a comma is reached, EOF is reached, or an error occurs.
+/// Also consumes an equals sign at the start if it is present.
 #[inline]
 pub fn skip_meta_item(input: ParseStream) {
-    input
-        .step(|cursor| {
-            let mut cur = *cursor;
-            while let Some((tt, next)) = cur.token_tree() {
-                if let TokenTree::Punct(punct) = tt {
-                    if punct.as_char() == ',' {
-                        break;
-                    }
-                }
-                cur = next;
+    input.parse::<Option<Token![=]>>().ok();
+    while !input.is_empty() && !input.peek(Token![,]) {
+        if input.peek(Token![<]) {
+            if input.parse::<AngleBracketedGenericArguments>().is_err() {
+                break
             }
-            Ok(((), cur))
-        })
-        .ok();
+        }
+        else if input.parse::<Expr>().is_err() {
+            break
+        }
+    }
 }
 
 /// Consumes all tokens left in a list of streams.


### PR DESCRIPTION
Resolves #26.

This PR changes `skip_meta_item` to check if `<` is the next token, parsing `AngleBracketedGenericArguments` if it does and `Expr` if it doesn't. It will repeat this check until a `,` token is found.

I'm not sure if this is the best way to fix this, but it's the way I fixed it for my current use-case